### PR TITLE
add docxtemplater.templateAsset.encoding property

### DIFF
--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -23,9 +23,8 @@ module.exports = (reporter, definition) => async (req, res) => {
   } else {
     if (!Buffer.isBuffer(templateAsset.content)) {
       let encoding = templateAsset.encoding
-      if(!encoding)
-      {
-        encoding = "utf8"
+      if (!encoding) {
+        encoding = 'utf8'
       }
       templateAsset.content = Buffer.from(templateAsset.content, encoding)
     }

--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -22,7 +22,12 @@ module.exports = (reporter, definition) => async (req, res) => {
     }
   } else {
     if (!Buffer.isBuffer(templateAsset.content)) {
-      templateAsset.content = Buffer.from(templateAsset.content)
+      let encoding = templateAsset.encoding
+      if(!encoding)
+      {
+        encoding = "utf8"
+      }
+      templateAsset.content = Buffer.from(templateAsset.content, encoding)
     }
   }
 

--- a/studio/main_dev.js
+++ b/studio/main_dev.js
@@ -10,7 +10,7 @@ Studio.addApiSpec({
         encoding: '...',
         content: '...'
       },
-      templateAssetShortid : '...'
+      templateAssetShortid: '...'
     }
   }
 })

--- a/studio/main_dev.js
+++ b/studio/main_dev.js
@@ -6,10 +6,11 @@ Studio.addPropertiesComponent(Properties.title, Properties, (entity) => entity._
 Studio.addApiSpec({
   template: {
     docxtemplater: {
-      assetTemplate: {
-        shortid: '...',
+      templateAsset: {
+        encoding: '...',
         content: '...'
-      }
+      },
+      templateAssetShortid : '...'
     }
   }
 })


### PR DESCRIPTION
To make possible to use different encoding, for instance, "base64" instead of "utf8".
Updated the API specification, seems it was incorrect.